### PR TITLE
Escape searchterm so regex characters are possible

### DIFF
--- a/stashapp.py
+++ b/stashapp.py
@@ -90,6 +90,7 @@ class StashInterface(GQLWrapper):
 		return result[queryType]
 
 	def __match_alias_item(self, search, items):
+		search = re.escape(search)
 		item_matches = {}
 		for item in items:
 			if re.match(rf'{search}$', item["name"], re.IGNORECASE):


### PR DESCRIPTION
This basically lead to errors when there were for example paranthesis in tags/performers/studios search term. They would return empty and even break when exist=true is set, because no entry of the same name can then be created (which is a good thing).