### PR TITLE
Fix tags to tag_ids mapping

### DIFF
--- a/stashapp.py
+++ b/stashapp.py
@@ -560,8 +560,8 @@ class StashInterface(GQLWrapper):
 	def map_tag_ids(self, tags_input, create=False):
 		tag_ids = []
 		for tag_input in tags_input:
-			if tag_id := self.find_tag(tag_input, create=create, on_multiple=OnMultipleMatch.RETURN_NONE):
-				tag_ids.append(tag_id)
+			if tag := self.find_tag(tag_input, create=create, on_multiple=OnMultipleMatch.RETURN_NONE):
+				tag_ids.append(tag["id"])
 		return tag_ids
 
 	# Performer CRUD


### PR DESCRIPTION
Fixes a bug in the mapping from text tags to tag ids.

Error message before:
```
2024-02-16 00:10:12Error   [Plugin / MetaDataJson] 422 Unprocessable Entity GQL data response is null
2024-02-16 00:10:12Error   [Plugin / MetaDataJson] GRAPHQL_VALIDATION_FAILED: cannot use map as ID ['variable', 'input', 'tag_ids', 0]
2024-02-16 00:10:12Error   [Plugin / MetaDataJson] 422 Unprocessable Entity query failed. v0.24.1-0
```

Instead of the numeric ID the full tag object was used:
```
'tag_ids': [{'aliases': [], ...
```