### PR TITLE
Add database locked error handling and new function to support stashapp-tag-importer changes.

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -241,6 +241,11 @@ fragment TypeRef on __Type {
 		except ValueError:
 			content = {}
 
+		# Set database locked bit to 0 on fresh response.
+		# Database locked errors send a 200 response code (normal),
+		# so they are not handled correctly without special intervention.
+		database_locked = 0
+
 		for error in content.get("errors", []):
 			message = error.get("message")
 			if len(message) > 2500:
@@ -249,6 +254,10 @@ fragment TypeRef on __Type {
 			if message == "must not be null":
 				code = "DATABASE_ERROR"
 				self.log.error("Database potentially malformed check your DB file")
+			if "database is locked" in message:
+				# If the database is locked, set the database_locked bit.
+				code = "DATABASE_LOCKED"
+				database_locked = 1
 			path = error.get("path", "")
 			fmt_error = f"{code}: {message} {path}".strip()
 			self.log.error(fmt_error)
@@ -260,6 +269,9 @@ fragment TypeRef on __Type {
 				self.log.error(f"{response.status_code} {response.reason}. Could not access endpoint {self.url}. Did you provide an API key? ")
 		elif content.get("data") == None:
 			self.log.error(f"{response.status_code} {response.reason} GQL data response is null")
+		elif database_locked == 1:
+			# If the database_locked bit is set, log error and proceed to exception.
+			self.log.error("Database is temporarily locked.")
 		elif response.status_code == 200:
 			return content["data"]
 		error_msg = f"{response.status_code} {response.reason} query failed. {self.version}"

--- a/marker_parse.py
+++ b/marker_parse.py
@@ -135,7 +135,7 @@ def import_scene_markers(stash:StashInterface, scraped_markers, stash_scene_id, 
 	"""
 
 	mapped_markers = [Marker.from_scrape(m, stash_scene_id, stash) for m in scraped_markers]
-	stash_markers = [Marker.from_gql(m) for m in stash.find_scene_markers(stash_scene_id, fragment=SCENE_MARKER_FRAGMENT)]    
+	stash_markers = [Marker.from_gql(m) for m in stash.get_scene_markers(stash_scene_id, fragment=SCENE_MARKER_FRAGMENT)]    
 
 	# merges scraped markers within distance of each other into one marker 
 	mapped_markers = merge_markers(mapped_markers, closest_allowed_common_marker)

--- a/stashapp.py
+++ b/stashapp.py
@@ -1548,7 +1548,8 @@ class StashInterface(GQLWrapper):
 		return self._callGraphQL(query, {"merge_input":merge_input})["sceneMerge"]
 
 	# Markers CRUD
-	def find_scene_markers(self, scene_id, fragment=None) -> list:
+	def get_scene_markers(self, scene_id, fragment=None) -> list:
+		"""Gets markers matching a scene_id."""
 		query = """
 			query FindSceneMarkers($scene_id: ID) {
 				findScene(id: $scene_id) {
@@ -1563,8 +1564,8 @@ class StashInterface(GQLWrapper):
 
 		variables = { "scene_id": scene_id }
 		return self._callGraphQL(query, variables)["findScene"]["scene_markers"]
-	def find_scene_markers_filter(self, scene_marker_filter, fragment=None) -> list:
-		""" Finds markers matching a SceneMarkerFilterType dict, as find_scene_markers() only takes a scene ID.
+	def find_scene_markers(self, scene_marker_filter, fragment=None) -> list:
+		"""Finds markers matching a SceneMarkerFilterType dict, as get_scene_markers() only takes a scene_id.
 		This is useful for finding a list of markers that use a specifc tag.
 
 		Args:
@@ -1574,6 +1575,12 @@ class StashInterface(GQLWrapper):
 		Returns:
 			dict: containing markers matching the filter
 		"""
+
+		# Catch legacy find_scene_markers() calls and redirect to get_scene_markers().
+		if not isinstance(scene_marker_filter, dict):
+			self.log.warning("find_scene_markers() no longer accepts scene_id, use get_scene_markers() instead")
+			return self.get_scene_markers(scene_marker_filter)
+
 		query = """
 			query findSceneMarkers($scene_marker_filter: SceneMarkerFilterType, $filter: FindFilterType) {
 				findSceneMarkers(scene_marker_filter: $scene_marker_filter, filter: $filter) {

--- a/stashapp.py
+++ b/stashapp.py
@@ -1563,6 +1563,31 @@ class StashInterface(GQLWrapper):
 
 		variables = { "scene_id": scene_id }
 		return self._callGraphQL(query, variables)["findScene"]["scene_markers"]
+	def find_scene_markers_filter(self, scene_marker_filter, fragment=None) -> list:
+		""" Finds markers matching a SceneMarkerFilterType dict, as find_scene_markers() only takes a scene ID.
+		This is useful for finding a list of markers that use a specifc tag.
+
+		Args:
+			 scene_marker_filter (SceneMarkerFilterType, optional)
+			 	See https://github.com/stashapp/stash/blob/develop/pkg/models/scene_marker.go for details on SceneMarkerFilterType
+
+		Returns:
+			dict: containing markers matching the filter
+		"""
+		query = """
+			query findSceneMarkers($scene_marker_filter: SceneMarkerFilterType, $filter: FindFilterType) {
+				findSceneMarkers(scene_marker_filter: $scene_marker_filter, filter: $filter) {
+					scene_markers {
+						...SceneMarker
+					}
+				}
+			}
+		"""
+		if fragment:
+			query = re.sub(r'\.\.\.SceneMarker', fragment, query)
+
+		variables = { "scene_marker_filter": scene_marker_filter }
+		return self._callGraphQL(query, variables)["findSceneMarkers"]["scene_markers"]
 	def create_scene_marker(self, marker_create_input:dict, fragment=None):
 		query = """
 			mutation SceneMarkerCreate($marker_input: SceneMarkerCreateInput!) {

--- a/stashapp.py
+++ b/stashapp.py
@@ -1549,7 +1549,14 @@ class StashInterface(GQLWrapper):
 
 	# Markers CRUD
 	def get_scene_markers(self, scene_id, fragment=None) -> list:
-		"""Gets markers matching a scene_id."""
+		""" returns a list of markers for a particular Scene given the scene_id
+		
+		Args:
+			scene_id: the stash ID of the scene to get markers for
+		
+		Returns:
+			list: list of marker objects from stash
+		"""
 		query = """
 			query FindSceneMarkers($scene_id: ID) {
 				findScene(id: $scene_id) {
@@ -1627,15 +1634,15 @@ class StashInterface(GQLWrapper):
 
 	# BULK Markers
 	def destroy_scene_markers(self, scene_id:int):
-		scene_markers = self.find_scene_markers(scene_id, fragment="id")
+		scene_markers = self.get_scene_markers(scene_id, fragment="id")
 		for marker in scene_markers:
 			self.destroy_scene_marker(marker["id"])
 	def merge_scene_markers(self, target_scene_id: int, source_scene_ids: list):
-		existing_marker_timestamps = [marker["seconds"] for marker in self.find_scene_markers(target_scene_id)]
+		existing_marker_timestamps = [marker["seconds"] for marker in self.get_scene_markers(target_scene_id)]
 
 		markers_to_merge = []
 		for source_scene_id in source_scene_ids:
-			markers_to_merge.extend(self.find_scene_markers(source_scene_id))
+			markers_to_merge.extend(self.get_scene_markers(source_scene_id))
 
 		created_markers = []
 		for marker in markers_to_merge:


### PR DESCRIPTION
This PR makes two changes that are required to support changes in [soundchaser128/
stashapp-tag-importer](https://github.com/soundchaser128/stashapp-tag-importer/pull/1):
- Adds error handling for when the database is locked.
  - When GraphQL's database is locked, it returns a response code of 200 which is "normal," but the GraphQL query actually fails.
  - This change looks for the phrase "database is locked" in the response message and then manually triggers an error.
  - Since it produces an error, applications use their own error handling to retry API calls that fail due to database locks.
- Adds a find_scene_markers_filter() function for detailed marker search.
  - The find_scene_markers() only takes a scene ID, this functions takes a SceneMarkerFilterType dict which can filter markers by tag, performer, etc. 
  - This is used heavily by stashapp-tag-importer to find markers and update / propagate associated tags.
  - Technically, find_scene_markers() could be updated to take the above SceneMarkerFilterType dict, but I didn't want to break any existing things that use the ID only input for that function.