### PR TITLE
Fix regular expression for version parsing

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -284,7 +284,7 @@ class StashVersion:
 			self.parse(f"{version_in['version']}-{version_in['hash']}")
 
 	def parse(self, ver_str) -> None:
-		m = re.search(r'v(?P<MAJOR>\d+)\.(?P<MINOR>\d+)\.(?P<PATCH>\d+)(?:-(?P<BUILD>\d+))?(?:-(?P<HASH>[a-z0-9]{9}))?', ver_str)
+		m = re.search(r'v(?P<MAJOR>\d+)\.(?P<MINOR>\d+)\.(?P<PATCH>\d+)(?:-(?P<BUILD>\d+)?(?:-(?P<HASH>[a-z0-9]{9})))?', ver_str)
 		if m:
 			m = m.groupdict()
 		else:


### PR DESCRIPTION
The regular expression used to parse Stash versions could in 62.5% of cases cause the hash to be parsed as a build number, breaking comparisons

```py
from stashapi.classes import StashVersion
testcases = [
    StashVersion({"hash": "76648fee", "version": "v0.27.2"}), # Current release
    StashVersion({"hash": "5f690d96", "version": "v0.27.2-24-g5f690d96"}), # Built a few months back
    StashVersion({"hash": "0621d871", "version": "v0.27.2-37-g0621d871"}), # Built last week
]
for v0, v1 in zip(testcases, testcases[1:]):
  assert v0 < v1, f"Incorrect comparison between version {v0} and {v1}
```

This throws `AssertionError: Wrong comparison between version v0.27.2-76648 and v0.27.2-24-g5f690d96`

This patch changes the regular expression so that it only grabs the hash and build number if both are present