### PR TITLE
fix: use correct key in publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.6.1"
-          python-version-file: pyproject.toml
+          pyproject-file: pyproject.toml
 
       - name: Install the project
         run: uv sync


### PR DESCRIPTION
I pushed a tag for this commit too, but idk if that will carry over in the merge. Might have to manually create it in the base repo as well.

I don't think the PyPI upload will work until a tag has been created, because `hatch` is setting the python version based on the git tag, and defaulting to some weirdness when there is no tag. I think future revisions might work (because the tag will at least contain something?) but I'm not entirely sure. I think it's _probably_ fine to only be able to push explicitly tagged commits to PyPI though? If not, easy fix.