### PR TITLE
fix: make pypi build checkout with tags

### DIFF
--- a/.github/workflows/pypi_test.yml
+++ b/.github/workflows/pypi_test.yml
@@ -6,6 +6,11 @@ on:
     types: [created]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Branch to build and publish'
+        required: true
+        default: 'main'
 
 jobs:
   upload:
@@ -16,7 +21,8 @@ jobs:
       - name: "Checkout repository and submodules"
         uses: actions/checkout@v4
         with:
-          ref: pypi
+          ref: ${{branch}}
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
I think the checkout action wasn't pulling tags, which would explain why `hatch` didn't pick one up. Also I added branch selection so you can just type in the branch name when manually running the action.