### PR TITLE
add missing create_missing_performer and urls from list_scrapers

### DIFF
--- a/src/stashapi/scrape_parser.py
+++ b/src/stashapi/scrape_parser.py
@@ -369,6 +369,9 @@ class ScrapeParser:
             except:
                 log.warning(f'Could not map performer Gender "{scrape["gender"]}" for {scrape["name"]}')
 
+        if self.create_missing_performers:
+            return self.stash.find_performer(performer_update, create=True)
+            
         return performer_update
 
     def scene_from_scrape(self, scene):

--- a/src/stashapi/stashapp.py
+++ b/src/stashapi/stashapp.py
@@ -1928,11 +1928,11 @@ class StashInterface(GQLWrapper):
 			listScrapers(types: $types) {
 			  id
 			  name
-			  performer { supported_scrapes }
-			  scene { supported_scrapes }
-			  gallery { supported_scrapes }
-			  movie { supported_scrapes }
-              image { supported_scrapes }
+			  performer { urls, supported_scrapes }
+			  scene { urls, supported_scrapes }
+			  gallery { urls, supported_scrapes }
+			  movie { urls, supported_scrapes }
+              image { urls, supported_scrapes }
 			}
 		  }
 		"""


### PR DESCRIPTION
adds the creation of missing performers to `performer_from_scrape` like with other `*_from_scrape` methods and returns full ScraperSpec (with `urls`) for `find_scrapers`