### PR TITLE
Fix: KeyError blocking 401 response handling

### DIFF
--- a/src/stashapi/classes.py
+++ b/src/stashapi/classes.py
@@ -265,15 +265,17 @@ fragment TypeRef on __Type {
             else:
                 self.log.error(f"{code}:{path} {message}".strip())
 
-        deprecation_dict = self.deprecations.get("Query",{}) | self.deprecations.get("Mutation",{})
-        query_type = list(content["data"].keys())[0]
-        if query_type in deprecation_dict:
-            self.log.warning(deprecation_dict[query_type])
+        if "data" in content:
+            deprecation_dict = self.deprecations.get("Query",{}) | self.deprecations.get("Mutation",{})
+            query_type = list(content["data"].keys())[0]
+            if query_type in deprecation_dict:
+                self.log.warning(deprecation_dict[query_type])
 
         if response.status_code == 401:
             self.log.error(
                 f"{response.status_code} {response.reason}. Could not access endpoint {self.url}. Did you provide an API key? Are you running a proxy?"
             )
+            raise Exception("Authentication error")
         elif content.get("data") == None:
             self.log.error(f"{response.status_code} {response.reason} GQL data response is null")
         elif database_locked == 1:


### PR DESCRIPTION
When accessing a secured Stash with an empty or incorrect API key, you get a slightly helpful error message followed by a less helpful one:

```
eCould not connect to Stash at http://localhost:9999/graphql
e'data'
```

There's an unsafe dictionary access in _handle_GQL_response(). For example, a 401 (unauthorized) response with an empty body gives an empty dict, it gets subscripted in the query_type lookup, causes a KeyError exception, and prevents the 401 status code response handler from ever being reached. In addition, the empty dict that the method would have returned would cause another KeyError back up the chain in stash_version() (and probably still does in other methods for various connection edge cases, but whatever).

I added a key check around the offending section, and raised a generic "Authentication error" exception in the 401 handler, allowing the logic to proceed as intended without causing additional problems along the way:

```
e401 Unauthorized. Could not access endpoint http://localhost:9999/graphql. Did you provide an API key? Are you running a proxy?
eCould not connect to Stash at http://localhost:9999/graphql
eAuthentication error
```